### PR TITLE
fix: Player 곡 정보 로딩 수정

### DIFF
--- a/src/app/player/songData.tsx
+++ b/src/app/player/songData.tsx
@@ -34,7 +34,7 @@ export default function SongData({
     const fetchData = async () => {
       const searchPayload = {
         filter: {
-          property: "Title",
+          property: "Song",
           title: {
             equals: name,
           },

--- a/src/app/player/songData.tsx
+++ b/src/app/player/songData.tsx
@@ -34,7 +34,7 @@ export default function SongData({
     const fetchData = async () => {
       const searchPayload = {
         filter: {
-          property: "Song",
+          property: "Title",
           title: {
             equals: name,
           },


### PR DESCRIPTION
songData.tsx에서 Notion 속성 이름을 'Title'에서 'Song'으로 수정하여
Player와 일치하도록 변경. 이로 인해 mp3 재생 시 곡 상세정보가
올바르게 표시됩니다.